### PR TITLE
Initial support for Gamma settings

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrantDeck",
   "author": "Scrumplex",
-  "flags": [],
+  "flags": ["debug"],
   "publish": {
     "tags": ["vibrant", "saturation"],
     "description": "Set vibrancy (saturation) of your screen",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,9 @@ const Content: VFC<{ runningApps: RunningApps, applyFn: (appId: string) => void 
   const [currentTargetGammaBlue, setCurrentTargetGammaBlue] = useState<number>(100);
 
   const refresh = () => {
+    // prevent updates while we are reloading
+    setInitialized(false);
+
     const activeApp = RunningApps.active();
     // does active app have a saved setting
     setCurrentAppOverride(settings.perApp[activeApp]?.hasSettings() || false);
@@ -55,57 +58,55 @@ const Content: VFC<{ runningApps: RunningApps, applyFn: (appId: string) => void 
     // get configured saturation for current app (also Deck UI!)
     setCurrentTargetSaturation(settings.appSaturation(activeApp));
     setCurrentTargetGammaLinear(settings.appGamma(activeApp).linear);
-    setCurrentTargetGammaRed(settings.appGamma(activeApp).gain_r);
-    setCurrentTargetGammaGreen(settings.appGamma(activeApp).gain_g);
-    setCurrentTargetGammaBlue(settings.appGamma(activeApp).gain_b);
+    setCurrentTargetGammaRed(settings.appGamma(activeApp).gainR);
+    setCurrentTargetGammaGreen(settings.appGamma(activeApp).gainG);
+    setCurrentTargetGammaBlue(settings.appGamma(activeApp).gainB);
 
     setInitialized(true);
   }
 
   useEffect(() => {
-    const activeApp = RunningApps.active();
     if (!initialized)
       return;
 
+    let activeApp = RunningApps.active();
     if (currentAppOverride && currentAppOverridable) {
       console.log(`Setting app ${activeApp} to saturation ${currentTargetSaturation}`);
-      settings.ensureApp(activeApp).saturation = currentTargetSaturation;
     } else {
       console.log(`Setting global to saturation ${currentTargetSaturation}`);
-      settings.ensureApp(DEFAULT_APP).saturation = currentTargetSaturation;
+      activeApp = DEFAULT_APP;
     }
-    applyFn(activeApp);
+    settings.ensureApp(activeApp).saturation = currentTargetSaturation;
+    applyFn(RunningApps.active());
 
     saveSettingsToLocalStorage(settings);
   }, [currentTargetSaturation, initialized]);
 
   useEffect(() => {
-    const activeApp = RunningApps.active();
     if (!initialized)
       return;
 
+    let activeApp = RunningApps.active();
     if (currentAppOverride && currentAppOverridable) {
       console.log(`Setting app ${activeApp} to${currentTargetGammaLinear ? " linear" : ""} gamma ${currentTargetGammaRed} ${currentTargetGammaGreen} ${currentTargetGammaBlue}`);
-      settings.ensureApp(activeApp).ensureGamma().linear = currentTargetGammaLinear;
-      settings.ensureApp(activeApp).ensureGamma().gain_r = currentTargetGammaRed;
-      settings.ensureApp(activeApp).ensureGamma().gain_g = currentTargetGammaGreen;
-      settings.ensureApp(activeApp).ensureGamma().gain_b = currentTargetGammaBlue;
     } else {
       console.log(`Setting global to${currentTargetGammaLinear ? " linear" : ""} gamma ${currentTargetGammaRed} ${currentTargetGammaGreen} ${currentTargetGammaBlue}`);
-      settings.ensureApp(DEFAULT_APP).ensureGamma().linear = currentTargetGammaLinear;
-      settings.ensureApp(DEFAULT_APP).ensureGamma().gain_r = currentTargetGammaRed;
-      settings.ensureApp(DEFAULT_APP).ensureGamma().gain_g = currentTargetGammaGreen;
-      settings.ensureApp(DEFAULT_APP).ensureGamma().gain_b = currentTargetGammaBlue;
+      activeApp = DEFAULT_APP;
     }
-    applyFn(activeApp);
+    settings.ensureApp(activeApp).ensureGamma().linear = currentTargetGammaLinear;
+    settings.ensureApp(activeApp).ensureGamma().gainR = currentTargetGammaRed;
+    settings.ensureApp(activeApp).ensureGamma().gainG = currentTargetGammaGreen;
+    settings.ensureApp(activeApp).ensureGamma().gainB = currentTargetGammaBlue;
+    applyFn(RunningApps.active());
 
     saveSettingsToLocalStorage(settings);
   }, [currentTargetGammaLinear, currentTargetGammaRed, currentTargetGammaGreen, currentTargetGammaBlue, initialized]);
 
   useEffect(() => {
-    const activeApp = RunningApps.active();
     if (!initialized)
       return;
+
+    const activeApp = RunningApps.active();
     if (activeApp == DEFAULT_APP)
       return;
 
@@ -116,9 +117,9 @@ const Content: VFC<{ runningApps: RunningApps, applyFn: (appId: string) => void 
       settings.ensureApp(activeApp).gamma = undefined;
       setCurrentTargetSaturation(settings.appSaturation(DEFAULT_APP));
       setCurrentTargetGammaLinear(settings.appGamma(DEFAULT_APP).linear);
-      setCurrentTargetGammaRed(settings.appGamma(DEFAULT_APP).gain_r);
-      setCurrentTargetGammaGreen(settings.appGamma(DEFAULT_APP).gain_g);
-      setCurrentTargetGammaBlue(settings.appGamma(DEFAULT_APP).gain_b);
+      setCurrentTargetGammaRed(settings.appGamma(DEFAULT_APP).gainR);
+      setCurrentTargetGammaGreen(settings.appGamma(DEFAULT_APP).gainG);
+      setCurrentTargetGammaBlue(settings.appGamma(DEFAULT_APP).gainB);
     }
     saveSettingsToLocalStorage(settings);
   }, [currentAppOverride, initialized]);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -113,6 +113,7 @@ const Content: VFC<{ runningApps: RunningApps, applyFn: (appId: string) => void 
 
     if (!currentAppOverride) {
       settings.ensureApp(activeApp).saturation = undefined;
+      settings.ensureApp(activeApp).gamma = undefined;
       setCurrentTargetSaturation(settings.appSaturation(DEFAULT_APP));
       setCurrentTargetGammaLinear(settings.appGamma(DEFAULT_APP).linear);
       setCurrentTargetGammaRed(settings.appGamma(DEFAULT_APP).gain_r);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,7 +62,11 @@ export class Settings {
 
   appGamma(appId: string) {
     // app gamma or global gamma or fallback to defaults
-    return this.perApp[appId]?.gamma || this.perApp[DEFAULT_APP]?.gamma || new GammaSetting();
+    if (this.perApp[appId]?.gamma != undefined)
+      return this.perApp[appId].gamma!!;
+    if (this.perApp[DEFAULT_APP]?.gamma != undefined)
+      return this.perApp[DEFAULT_APP].gamma!!;
+    return new GammaSetting();
   }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,12 +6,34 @@ const SETTINGS_KEY = "vibrantDeck";
 const serializer = new JsonSerializer();
 
 @JsonObject()
+export class GammaSetting {
+  @JsonProperty()
+  linear: boolean = true;
+  @JsonProperty()
+  gain_r: number = 100;
+  @JsonProperty()
+  gain_g: number = 100;
+  @JsonProperty()
+  gain_b: number = 100;
+}
+
+@JsonObject()
 export class AppSetting {
   @JsonProperty()
   saturation?: number;
+  @JsonProperty()
+  gamma?: GammaSetting;
+
+  ensureGamma(): GammaSetting {
+    if (this.gamma == undefined)
+      this.gamma = new GammaSetting();
+    return this.gamma;
+  }
 
   hasSettings(): boolean {
     if (this.saturation != undefined)
+      return true;
+    if (this.gamma != undefined)
       return true;
     return false;
   }
@@ -36,6 +58,11 @@ export class Settings {
     if (this.perApp[DEFAULT_APP]?.saturation != undefined)
       return this.perApp[DEFAULT_APP].saturation!!;
     return 100;
+  }
+
+  appGamma(appId: string) {
+    // app gamma or global gamma or fallback to defaults
+    return this.perApp[appId]?.gamma || this.perApp[DEFAULT_APP]?.gamma || new GammaSetting();
   }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,11 +10,11 @@ export class GammaSetting {
   @JsonProperty()
   linear: boolean = true;
   @JsonProperty()
-  gain_r: number = 100;
+  gainR: number = 100;
   @JsonProperty()
-  gain_g: number = 100;
+  gainG: number = 100;
   @JsonProperty()
-  gain_b: number = 100;
+  gainB: number = 100;
 }
 
 @JsonObject()

--- a/src/util.ts
+++ b/src/util.ts
@@ -67,8 +67,8 @@ export class Backend {
 
   applyGamma(gamma: GammaSetting) {
     const defaults = new GammaSetting();
-    const default_values = [defaults.gain_r / 100.0, defaults.gain_g / 100.0, defaults.gain_b / 100.0]
-    const values = [gamma.gain_r / 100.0, gamma.gain_g / 100.0, gamma.gain_b / 100.0];
+    const default_values = [defaults.gainR / 100.0, defaults.gainG / 100.0, defaults.gainB / 100.0]
+    const values = [gamma.gainR / 100.0, gamma.gainG / 100.0, gamma.gainB / 100.0];
     console.log(`Applying gamma ${gamma.linear ? "linear" : ""} gain ${values.toString()}`);
     if (gamma.linear) {
       this.serverAPI.callPluginMethod<GammaGainArgs, boolean>("set_gamma_gain", { "values": default_values });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,14 @@
 import { Router, ServerAPI } from "decky-frontend-lib";
+import { GammaSetting } from "./settings";
 
 interface SaturationArgs {
   saturation: number
+}
+interface GammaGainArgs {
+  values: number[]
+}
+interface GammaBlendArgs {
+  value: number
 }
 
 type ActiveAppChangedHandler = (newAppId: string, oldAppId: string) => void;
@@ -56,5 +63,21 @@ export class Backend {
   applySaturation(saturation: number) {
     console.log("Applying saturation " + saturation.toString());
     this.serverAPI.callPluginMethod<SaturationArgs, boolean>("set_saturation", { "saturation": saturation / 100.0 });
+  }
+
+  applyGamma(gamma: GammaSetting) {
+    const defaults = new GammaSetting();
+    const default_values = [defaults.gain_r / 100.0, defaults.gain_g / 100.0, defaults.gain_b / 100.0]
+    const values = [gamma.gain_r / 100.0, gamma.gain_g / 100.0, gamma.gain_b / 100.0];
+    console.log(`Applying gamma ${gamma.linear ? "linear" : ""} gain ${values.toString()}`);
+    if (gamma.linear) {
+      this.serverAPI.callPluginMethod<GammaGainArgs, boolean>("set_gamma_gain", { "values": default_values });
+      this.serverAPI.callPluginMethod<GammaGainArgs, boolean>("set_gamma_linear_gain", { "values": values });
+      this.serverAPI.callPluginMethod<GammaBlendArgs, boolean>("set_gamma_linear_gain_blend", { "value": 1.0 });
+    } else {
+      this.serverAPI.callPluginMethod<GammaGainArgs, boolean>("set_gamma_gain", { "values": values });
+      this.serverAPI.callPluginMethod<GammaGainArgs, boolean>("set_gamma_linear_gain", { "values": default_values });
+      this.serverAPI.callPluginMethod<GammaBlendArgs, boolean>("set_gamma_linear_gain_blend", { "value": 0.0 });
+    }
   }
 }


### PR DESCRIPTION
In an effort to support more color correction options, add gamma color
gain settings. See libvibrant/vibrantDeck#1

This does not include support for setting degamma/gamma exponents, as
there needs to be a user-friendly way of setting them.

