### PR TITLE
Separate settings for external display

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import glob
 import os
 import sys
 import struct
@@ -121,3 +122,14 @@ class Plugin:
             return saturation
 
         return 1.0
+    
+    async def get_displays(self) -> List[str]:
+        displays = []
+        display_status_files = glob.glob("/sys/class/drm/*/status")
+        for filename in display_status_files:
+            with open(filename) as f:
+                status = f.read()
+                if status.startswith("connected"):
+                    displays.append(filename.split('/')[4])
+
+        return displays

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -374,7 +374,7 @@ export default definePlugin((serverAPI: ServerAPI) => {
     backend.applyGamma(new GammaSetting());
   };
 
-  const listenForChanges = (enabled: boolean) => {
+  const listenForRunningApps = (enabled: boolean) => {
     if (enabled) {
       console.log("Listening for actively running apps");
       runningApps.register();
@@ -393,7 +393,7 @@ export default definePlugin((serverAPI: ServerAPI) => {
 
   runningApps.listenActiveChange(() => applySettings(RunningApps.active(), externalDisplayState.current()));
   externalDisplayState.listenChange(() => applySettings(RunningApps.active(), externalDisplayState.current()));
-  listenForChanges(settings.getEnabled(true) || settings.getEnabled(false));
+  listenForRunningApps(settings.getEnabled(true) || settings.getEnabled(false));
 
   return {
     title: <div className={staticClasses.Title}>vibrantDeck</div>,
@@ -401,7 +401,7 @@ export default definePlugin((serverAPI: ServerAPI) => {
       <Content
         applyFn={applySettings}
         resetFn={resetSettings}
-        listenModeFn={listenForChanges}
+        listenModeFn={listenForRunningApps}
         externalDisplayState={externalDisplayState}
       />
     ),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -241,6 +241,7 @@ const Content: VFC<{
               step={1}
               max={400}
               min={0}
+              resetValue={100}
               showValue={true}
               onChange={(saturation: number) => {
                 setCurrentTargetSaturation(saturation);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,34 +43,54 @@ export class AppSetting {
 @JsonObject()
 export class Settings {
   @JsonProperty()
-  enabled: boolean = true;
+  private enabled: boolean = true;
   @JsonProperty({ dataStructure: "dictionary", type: AppSetting })
   perApp: { [appId: string]: AppSetting } = {};
   @JsonProperty()
   advancedSettingsUI: boolean = true;
+  @JsonProperty()
+  externalEnabled: boolean = false;
+  @JsonProperty({ dataStructure: "dictionary", type: AppSetting })
+  externalPerApp: { [appId: string]: AppSetting } = {};
 
-  ensureApp(appId: string): AppSetting {
-    if (!(appId in this.perApp)) {
-      this.perApp[appId] = new AppSetting();
+  ensureApp(appId: string, external: boolean): AppSetting {
+    const appDict = external ? this.externalPerApp : this.perApp;
+    if (!(appId in appDict)) {
+      appDict[appId] = new AppSetting();
     }
-    return this.perApp[appId];
+    return appDict[appId];
   }
 
-  appSaturation(appId: string): number {
+  getEnabled(external: boolean): boolean {
     // app saturation or global saturation or fallback 100
-    if (this.perApp[appId]?.saturation != undefined)
-      return this.perApp[appId].saturation!!;
-    if (this.perApp[DEFAULT_APP]?.saturation != undefined)
-      return this.perApp[DEFAULT_APP].saturation!!;
+    return external ? this.externalEnabled : this.enabled;
+  }
+
+  setEnabled(external: boolean, value: boolean) {
+    // app saturation or global saturation or fallback 100
+    if (external) {
+      this.externalEnabled = value;
+    } else {
+      this.enabled = value;
+    }
+  }
+
+  appSaturation(appId: string, external: boolean): number {
+    // app saturation or global saturation or fallback 100
+    const appDict = external ? this.externalPerApp : this.perApp;
+    if (appDict[appId]?.saturation != undefined)
+      return appDict[appId].saturation!!;
+    if (appDict[DEFAULT_APP]?.saturation != undefined)
+      return appDict[DEFAULT_APP].saturation!!;
     return 100;
   }
 
-  appGamma(appId: string) {
+  appGamma(appId: string, external: boolean) {
     // app gamma or global gamma or fallback to defaults
-    if (this.perApp[appId]?.gamma != undefined)
-      return this.perApp[appId].gamma!!;
-    if (this.perApp[DEFAULT_APP]?.gamma != undefined)
-      return this.perApp[DEFAULT_APP].gamma!!;
+    const appDict = external ? this.externalPerApp : this.perApp;
+    if (appDict[appId]?.gamma != undefined) return appDict[appId].gamma!!;
+    if (appDict[DEFAULT_APP]?.gamma != undefined)
+      return appDict[DEFAULT_APP].gamma!!;
     return new GammaSetting();
   }
 }


### PR DESCRIPTION
Would like to get some early feedback on this feature.

My issue is that I use the XReal Airs (NReal Airs) with the SteamDeck, and they require very different settings than the internal display. So I need to keep changing the settings when I connect / disconnect them.

I assume people who use the SD in docked mode a lot might have a similar issue - they don't want the same settings on their TV that they set for the SD display.

So this change will poll every 3s to see whether an external display was connected or not. Settings will maintain separate settings for internal and external displays and apply them when the change is detected.

Note: I defaulted to no color manipulation for external displays. I think most people use this plugin to change the internal display right now. However, people who had extensive per app settings for external display will be inconvenienced.

Note2: best would be to detect the ID of the external display and have separate settings for each. Couldn't figure that one out :(