### PR TITLE
Minimum darkness value increased to prevent regret.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -253,7 +253,7 @@ const Content: VFC<{
               value={currentTargetGammaRed}
               step={1}
               max={900}
-              min={-50}
+              min={5}
               resetValue={100}
               showValue={true}
               onChange={(value: number) => {
@@ -272,7 +272,7 @@ const Content: VFC<{
               value={currentTargetGammaRed}
               step={1}
               max={900}
-              min={-50}
+              min={5}
               resetValue={100}
               showValue={true}
               onChange={(value: number) => {
@@ -289,7 +289,7 @@ const Content: VFC<{
               value={currentTargetGammaGreen}
               step={1}
               max={900}
-              min={-50}
+              min={5}
               resetValue={100}
               showValue={true}
               onChange={(value: number) => {
@@ -306,7 +306,7 @@ const Content: VFC<{
               value={currentTargetGammaBlue}
               step={1}
               max={900}
-              min={-50}
+              min={5}
               resetValue={100}
               showValue={true}
               onChange={(value: number) => {


### PR DESCRIPTION
-50 for the various minimum values is dangerous (just see the issue requests), you can get your screen stuck in complete darkness, the new value makes it almost black, but in the right angles you can still see to bring the screen back to life.